### PR TITLE
String operations

### DIFF
--- a/src/main/scala/org/scanet/core/Output.scala
+++ b/src/main/scala/org/scanet/core/Output.scala
@@ -112,8 +112,14 @@ object Output {
       compileWithTransformer((inputs, builder) =>
         inputs.foldLeft(builder)((acc, next) => acc.addInput(next)))
 
+    def compileWithInputList: Builder[A, State with WithCompiler] =
+      compileWithTransformer((inputs, builder) => builder.addInputList(inputs.toArray))
+
     def compileWithAttr(name: String, tp: TensorType[_]): Builder[A, State with WithCompiler] =
       compileWithTransformer((_, builder) => builder.setAttr(name, tp.tag))
+
+    def compileWithAttr(name: String, str: String): Builder[A, State with WithCompiler] =
+      compileWithTransformer((_, builder) => builder.setAttr(name, str))
 
     def build(implicit ev: State =:= Complete): Output[A] = {
       core.Output[A](name, Option(label).getOrElse(name), shape, inputs, (context: OpContext[A]) => {

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -1,0 +1,72 @@
+package org.scanet.strings
+
+import org.scanet.core.TensorType.syntax._
+import org.scanet.core.{Output, TensorType, TfTypeString}
+import simulacrum.typeclass
+
+import scala.Ordering.Implicits._
+import scala.language.higherKinds
+
+@typeclass trait StringOps[F[_]] {
+
+  def concat[A: TensorType : StringLike](left: F[A], right: F[A]): F[A]
+
+  def length[A: TensorType : StringLike](op: F[A]): F[Int]
+
+//  def split[A: TensorType : StringLike](op: F[A], sep: F[String]): F[String]
+}
+
+trait StringLike[S]
+
+object StringOps {
+
+  trait Instances {
+    implicit def outputStringOps: StringOps[Output] = new OutputStringOps
+
+    implicit def stringLikeInst: StringLike[String] = new StringLike[String] with TfTypeString
+  }
+
+  trait Syntax extends Instances with StringOps.ToStringOpsOps {
+
+    def join(sep: String, ops: Output[String]*): Output[String] = {
+      require(ops.zip(ops.tail).forall({ case (o1, o2) => o1.broadcastableAny(o2) }))
+      Output.name[String]("StringJoin")
+        .shape(ops.map(_.shape).max)
+        .inputs(ops: _*)
+        .compileWithAttr("separator", sep)
+        .compileWithInputList
+        .build
+    }
+  }
+
+  object syntax extends Syntax
+
+}
+
+class OutputStringOps extends StringOps[Output] {
+
+  override def concat[A: TensorType : StringLike](left: Output[A], right: Output[A]): Output[A] = {
+    require(left.shape.broadcastableAny(right.shape))
+    Output.name[A]("StringJoin")
+      .shape(left.shape max right.shape)
+      .inputs(left, right)
+      .compileWithInputList
+      .build
+  }
+
+  override def length[A: TensorType : StringLike](op: Output[A]): Output[Int] = {
+    Output.name[Int]("StringLength")
+      .shape(op.shape)
+      .inputs(op)
+      .compileWithAllInputs
+      .build
+  }
+
+//  override def split[A: TensorType : StringLike](op: Output[A], sep: Output[String]): Output[String] = {
+//    Output.name[String]("StringSplitV2")
+//      .shape(op.shape) // TODO: this is wrong, result is SparseTensor with different shape
+//      .inputs(op, sep)
+//      .compileWithAllInputs
+//      .build
+//  }
+}

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -9,11 +9,49 @@ import scala.language.higherKinds
 
 @typeclass trait StringOps[F[_]] {
 
+  /** Concatenates current and given String tensors
+   *
+   * @param left side
+   * @param right side to append
+   * @return tensors containing joined corresponding strings of left and right tensors
+   */
   def concat[A: TensorType : StringLike](left: F[A], right: F[A]): F[A]
 
+  /** Computes the length of each string given in the input tensor.
+   *
+   * @return tensor with strings lengths
+   */
   def length[A: TensorType : StringLike](op: F[A]): F[Int]
 
-//  def split[A: TensorType : StringLike](op: F[A], sep: F[String]): F[String]
+  /** Converts each string in the input Tensor to the specified numeric type.
+   *
+   * @tparam B data type for output tensor
+   * @return tensor with parsed numbers
+   */
+  def toNumber[A: TensorType : StringLike, B: TensorType](op: F[A]): F[B]
+
+  /** Return substrings from tensor of strings.
+   *
+   * For each string in the input Tensor, creates a substring starting at index
+   * pos with a total length of len.
+   *
+   * If len defines a substring that would extend beyond the length of the input
+   * string, then as many characters as possible are used.
+   *
+   * A negative pos indicates distance within the string backwards from the end.
+   *
+   * If pos specifies an index which is out of range for any of the input strings,
+   * then an InvalidArgumentError is thrown.
+   *
+   * pos and len must have the same shape and supports broadcasting up to two dimensions
+   *
+   * @param pos - tensor of substring starting positions
+   * @param len - tensor of substrings lengths
+   * @return tensor of substrings
+   */
+  def substring[A: TensorType : StringLike](op: F[A], pos: F[Int], len: F[Int]): F[A]
+
+  //  def split[A: TensorType : StringLike](op: F[A], sep: F[String]): F[String]
 }
 
 trait StringLike[S]
@@ -28,6 +66,12 @@ object StringOps {
 
   trait Syntax extends Instances with StringOps.ToStringOpsOps {
 
+    /** Joins the strings in the given list of string tensors into one tensor with given separator
+     *
+     * @param sep elements separator
+     * @param ops list of string tensors to join
+     * @return single string tensor
+     */
     def join(sep: String, ops: Output[String]*): Output[String] = {
       require(ops.zip(ops.tail).forall({ case (o1, o2) => o1.broadcastableAny(o2) }))
       Output.name[String]("StringJoin")
@@ -62,11 +106,30 @@ class OutputStringOps extends StringOps[Output] {
       .build
   }
 
-//  override def split[A: TensorType : StringLike](op: Output[A], sep: Output[String]): Output[String] = {
-//    Output.name[String]("StringSplitV2")
-//      .shape(op.shape) // TODO: this is wrong, result is SparseTensor with different shape
-//      .inputs(op, sep)
-//      .compileWithAllInputs
-//      .build
-//  }
+  override def toNumber[A: TensorType : StringLike, B: TensorType](op: Output[A]): Output[B] = {
+    Output.name[B]("StringToNumber")
+      .shape(op.shape)
+      .inputs(op)
+      .compileWithAttr("out_type", TensorType[B])
+      .compileWithAllInputs
+      .build
+  }
+
+  override def substring[A: TensorType : StringLike](op: Output[A], pos: Output[Int], len: Output[Int]): Output[A] = {
+    require(pos.shape == len.shape)
+    require(op.shape.broadcastableBy(pos.shape))
+    Output.name[A]("Substr")
+      .shape(op.shape)
+      .inputs(op, pos, len)
+      .compileWithAllInputs
+      .build
+  }
+
+  //  override def split[A: TensorType : StringLike](op: Output[A], sep: Output[String]): Output[String] = {
+  //    Output.name[String]("StringSplitV2")
+  //      .shape(op.shape) // TODO: this is wrong, result is SparseTensor with different shape
+  //      .inputs(op, sep)
+  //      .compileWithAllInputs
+  //      .build
+  //  }
 }

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -58,8 +58,6 @@ import scala.language.higherKinds
    * @return tensor of substrings
    */
   def substring[A: TensorType : Textual](op: F[A], pos: F[Int], len: F[Int]): F[A]
-
-  //  def split[A: TensorType : StringLike](op: F[A], sep: F[String]): F[String]
 }
 
 trait Textual[S]
@@ -137,12 +135,4 @@ class OutputStringOps extends StringOps[Output] {
       .compileWithAllInputs
       .build
   }
-
-  //  override def split[A: TensorType : StringLike](op: Output[A], sep: Output[String]): Output[String] = {
-  //    Output.name[String]("StringSplitV2")
-  //      .shape(op.shape) // TODO: this is wrong, result is SparseTensor with different shape
-  //      .inputs(op, sep)
-  //      .compileWithAllInputs
-  //      .build
-  //  }
 }

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -17,7 +17,7 @@ import scala.language.higherKinds
    * @param right side to append
    * @return tensors containing joined corresponding strings of left and right tensors
    */
-  def concat[A: TensorType : StringLike](left: F[A], right: F[A]): F[A]
+  def concat[A: TensorType : Textual](left: F[A], right: F[A]): F[A]
 
   /** Computes the length of each string given in the input tensor.
    *
@@ -25,7 +25,7 @@ import scala.language.higherKinds
    *
    * @return tensor with strings lengths
    */
-  def length[A: TensorType : StringLike](op: F[A]): F[Int]
+  def length[A: TensorType : Textual](op: F[A]): F[Int]
 
   /** Converts each string in the input Tensor to the specified numeric type.
    *
@@ -34,7 +34,7 @@ import scala.language.higherKinds
    * @tparam B data type for output tensor
    * @return tensor with parsed numbers
    */
-  def toNumber[A: TensorType : StringLike, B: TensorType](op: F[A]): F[B]
+  def toNumber[A: TensorType : Textual, B: TensorType](op: F[A]): F[B]
 
   /** Return substrings from tensor of strings.
    *
@@ -57,19 +57,19 @@ import scala.language.higherKinds
    * @param len - tensor of substrings lengths
    * @return tensor of substrings
    */
-  def substring[A: TensorType : StringLike](op: F[A], pos: F[Int], len: F[Int]): F[A]
+  def substring[A: TensorType : Textual](op: F[A], pos: F[Int], len: F[Int]): F[A]
 
   //  def split[A: TensorType : StringLike](op: F[A], sep: F[String]): F[String]
 }
 
-trait StringLike[S]
+trait Textual[S]
 
 object StringOps {
 
   trait Instances {
     implicit def outputStringOps: StringOps[Output] = new OutputStringOps
 
-    implicit def stringLikeInst: StringLike[String] = new StringLike[String] {}
+    implicit def stringIsTextual: Textual[String] = new Textual[String] {}
   }
 
   trait Syntax extends Instances with StringOps.ToStringOpsOps {
@@ -100,7 +100,7 @@ object StringOps {
 
 class OutputStringOps extends StringOps[Output] {
 
-  override def concat[A: TensorType : StringLike](left: Output[A], right: Output[A]): Output[A] = {
+  override def concat[A: TensorType : Textual](left: Output[A], right: Output[A]): Output[A] = {
     require(left.shape.broadcastableAny(right.shape),
       s"cannot join tensors with shapes ${left.shape} + ${right.shape}")
     Output.name[A]("StringJoin")
@@ -110,7 +110,7 @@ class OutputStringOps extends StringOps[Output] {
       .build
   }
 
-  override def length[A: TensorType : StringLike](op: Output[A]): Output[Int] = {
+  override def length[A: TensorType : Textual](op: Output[A]): Output[Int] = {
     Output.name[Int]("StringLength")
       .shape(op.shape)
       .inputs(op)
@@ -118,7 +118,7 @@ class OutputStringOps extends StringOps[Output] {
       .build
   }
 
-  override def toNumber[A: TensorType : StringLike, B: TensorType](op: Output[A]): Output[B] = {
+  override def toNumber[A: TensorType : Textual, B: TensorType](op: Output[A]): Output[B] = {
     Output.name[B]("StringToNumber")
       .shape(op.shape)
       .inputs(op)
@@ -127,7 +127,7 @@ class OutputStringOps extends StringOps[Output] {
       .build
   }
 
-  override def substring[A: TensorType : StringLike](op: Output[A], pos: Output[Int], len: Output[Int]): Output[A] = {
+  override def substring[A: TensorType : Textual](op: Output[A], pos: Output[Int], len: Output[Int]): Output[A] = {
     require(pos.shape == len.shape, s"pos and len shapes are not equal ${pos.shape}, ${len.shape}")
     require(op.shape.broadcastableBy(pos.shape),
       s"string tensor shape (${op.shape}) is not broadcastable by len/pos shape ${pos.shape}")

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -11,6 +11,8 @@ import scala.language.higherKinds
 
   /** Concatenates current and given String tensors
    *
+   * {{{Tensor.vector("ab", "cd").const.concat("e".const).eval should be(Tensor.vector("abe", "cde")}}}
+   *
    * @param left side
    * @param right side to append
    * @return tensors containing joined corresponding strings of left and right tensors
@@ -19,11 +21,15 @@ import scala.language.higherKinds
 
   /** Computes the length of each string given in the input tensor.
    *
+   * {{{Tensor.vector("a", "bb").const.length.eval should be(Tensor.vector(1, 2))}}}
+   *
    * @return tensor with strings lengths
    */
   def length[A: TensorType : StringLike](op: F[A]): F[Int]
 
   /** Converts each string in the input Tensor to the specified numeric type.
+   *
+   * {{{Tensor.vector("1.1", "2.2").const.toNumber[Float].eval should be(Tensor.vector(1.1f, 2.2f))}}}
    *
    * @tparam B data type for output tensor
    * @return tensor with parsed numbers
@@ -44,6 +50,8 @@ import scala.language.higherKinds
    * then an InvalidArgumentError is thrown.
    *
    * pos and len must have the same shape and supports broadcasting up to two dimensions
+   *
+   * {{{"abcde".const.substring(1.const, 3.const).eval should be("bcd".const)}}}
    *
    * @param pos - tensor of substring starting positions
    * @param len - tensor of substrings lengths
@@ -67,6 +75,8 @@ object StringOps {
   trait Syntax extends Instances with StringOps.ToStringOpsOps {
 
     /** Joins the strings in the given list of string tensors into one tensor with given separator
+     *
+     * {{{join(",", "a".const, "b".const, "c".const).eval should be("a,b,c".const)}}}
      *
      * @param sep elements separator
      * @param ops list of string tensors to join

--- a/src/main/scala/org/scanet/strings/StringOps.scala
+++ b/src/main/scala/org/scanet/strings/StringOps.scala
@@ -1,7 +1,7 @@
 package org.scanet.strings
 
 import org.scanet.core.TensorType.syntax._
-import org.scanet.core.{Output, TensorType, TfTypeString}
+import org.scanet.core.{Output, TensorType}
 import simulacrum.typeclass
 
 import scala.Ordering.Implicits._
@@ -69,7 +69,7 @@ object StringOps {
   trait Instances {
     implicit def outputStringOps: StringOps[Output] = new OutputStringOps
 
-    implicit def stringLikeInst: StringLike[String] = new StringLike[String] with TfTypeString
+    implicit def stringLikeInst: StringLike[String] = new StringLike[String] {}
   }
 
   trait Syntax extends Instances with StringOps.ToStringOpsOps {

--- a/src/main/scala/org/scanet/strings/StringSyntax.scala
+++ b/src/main/scala/org/scanet/strings/StringSyntax.scala
@@ -1,0 +1,5 @@
+package org.scanet.strings
+
+import org.scanet.core.CoreSyntax
+
+trait StringSyntax extends CoreSyntax with StringOps.Syntax

--- a/src/main/scala/org/scanet/strings/package.scala
+++ b/src/main/scala/org/scanet/strings/package.scala
@@ -1,0 +1,6 @@
+package org.scanet
+
+package object strings {
+
+  object syntax extends StringSyntax
+}

--- a/src/test/scala/org/scanet/strings/StringOpsTest.scala
+++ b/src/test/scala/org/scanet/strings/StringOpsTest.scala
@@ -1,0 +1,39 @@
+package org.scanet.strings
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanet.core.Tensor
+import org.scanet.strings.syntax._
+
+class StringOpsTest extends AnyFlatSpec with Matchers {
+
+  "concat" should "concatenate two string vectors" in {
+    val a = Tensor.vector("1", "2").const
+    val b = Tensor.vector("3", "4").const
+
+    a.concat(b).eval should be(Tensor.vector("13", "24"))
+  }
+
+  "concat" should "concatenate with scalar" in {
+    val a = Tensor.vector("1", "2").const
+    val b = "3".const
+
+    a.concat(b).eval should be(Tensor.vector("13", "23"))
+  }
+
+  "length" should "return length of string elements" in {
+    Tensor.vector("a", "aa", "aaa").const.length.eval should be(Tensor.vector(1, 2, 3))
+  }
+
+  "join" should "concatenate multiple tensors with separator" in {
+    val a = Tensor.vector("1", "2").const
+    val b = Tensor.vector("3", "4").const
+    val c = Tensor.vector("5", "6").const
+
+    join(", ", a, b, c).eval should be(Tensor.vector("1, 3, 5", "2, 4, 6"))
+  }
+
+//  "split" should "split string values with given separator" in {
+//    Tensor.vector("a, b, c", "d, e").const.split(", ".const).eval should be(Tensor.vector("a", "b", "c", "d", "e"))
+//  }
+}

--- a/src/test/scala/org/scanet/strings/StringOpsTest.scala
+++ b/src/test/scala/org/scanet/strings/StringOpsTest.scala
@@ -49,8 +49,4 @@ class StringOpsTest extends AnyFlatSpec with Matchers {
 
     strings.const.substring(positions.const, lengths.const).eval should be(expected)
   }
-
-  //  "split" should "split string values with given separator" in {
-  //    Tensor.vector("a, b, c", "d, e").const.split(", ".const).eval should be(Tensor.vector("a", "b", "c", "d", "e"))
-  //  }
 }

--- a/src/test/scala/org/scanet/strings/StringOpsTest.scala
+++ b/src/test/scala/org/scanet/strings/StringOpsTest.scala
@@ -15,10 +15,7 @@ class StringOpsTest extends AnyFlatSpec with Matchers {
   }
 
   "concat" should "concatenate with scalar" in {
-    val a = Tensor.vector("1", "2").const
-    val b = "3".const
-
-    a.concat(b).eval should be(Tensor.vector("13", "23"))
+    Tensor.vector("1", "2").const.concat("3".const).eval should be(Tensor.vector("13", "23"))
   }
 
   "length" should "return length of string elements" in {
@@ -33,7 +30,27 @@ class StringOpsTest extends AnyFlatSpec with Matchers {
     join(", ", a, b, c).eval should be(Tensor.vector("1, 3, 5", "2, 4, 6"))
   }
 
-//  "split" should "split string values with given separator" in {
-//    Tensor.vector("a, b, c", "d, e").const.split(", ".const).eval should be(Tensor.vector("a", "b", "c", "d", "e"))
-//  }
+  "toNumber" should "parse string values" in {
+    Tensor.vector("1.1", "2.2", "3.3").const.toNumber[Float].eval should be(Tensor.vector(1.1f, 2.2f, 3.3f))
+  }
+
+  "substring" should "" in {
+    val strings = Tensor.matrix(
+      Array("ten", "eleven", "twelve"),
+      Array("thirteen", "fourteen", "fifteen'"),
+      Array("sixteen", "seventeen", "eighteen"))
+    val positions = Tensor.matrix(Array(1, 2, 3), Array(1, 2, 3), Array(1, 2, 3))
+    val lengths = Tensor.matrix(Array(2, 3, 4), Array(4, 3, 2), Array(5, 5, 5))
+
+    val expected = Tensor.matrix(
+      Array("en", "eve", "lve"),
+      Array("hirt", "urt", "te"),
+      Array("ixtee", "vente", "hteen"))
+
+    strings.const.substring(positions.const, lengths.const).eval should be(expected)
+  }
+
+  //  "split" should "split string values with given separator" in {
+  //    Tensor.vector("a, b, c", "d, e").const.split(", ".const).eval should be(Tensor.vector("a", "b", "c", "d", "e"))
+  //  }
 }

--- a/src/test/scala/org/scanet/strings/StringOpsTest.scala
+++ b/src/test/scala/org/scanet/strings/StringOpsTest.scala
@@ -34,7 +34,7 @@ class StringOpsTest extends AnyFlatSpec with Matchers {
     Tensor.vector("1.1", "2.2", "3.3").const.toNumber[Float].eval should be(Tensor.vector(1.1f, 2.2f, 3.3f))
   }
 
-  "substring" should "" in {
+  "substring" should "calculate substrings by given pos and len" in {
     val strings = Tensor.matrix(
       Array("ten", "eleven", "twelve"),
       Array("thirteen", "fourteen", "fifteen'"),


### PR DESCRIPTION
added some String operations: lengths, toNumber, substring, concat, join

Though I'm not confident in couple of points:
 * added trait `StringLike[S]` to restrict operations to `Output[String]` - is this correct?
 * I failed to implement `split` because I'm not sure which shape to use for operation (op returns sparse tensor), moreover currently we need tensor original shape to determine size of buffer to correctly read strings