### PR TITLE
gradient for Div op

### DIFF
--- a/src/main/scala/org/scanet/core/ConstOp.scala
+++ b/src/main/scala/org/scanet/core/ConstOp.scala
@@ -14,7 +14,7 @@ object ConstOp {
     Output.name[A]("Const")
       .shape(tensor.shape)
       .compileWithValue(tensor)
-      .localGrad[A](_ => List())
+      .localGrad(_ => List())
       .build
 
   trait Syntax {

--- a/src/main/scala/org/scanet/core/CoreOp.scala
+++ b/src/main/scala/org/scanet/core/CoreOp.scala
@@ -128,9 +128,7 @@ object CoreOp {
           Output.name[B]("Cast")
             .shape(op.shape)
             .inputs(op)
-            .localGrad[B](ctx => {
-              List(cast[B, A](ctx.parentGrad))
-            })
+            .localGrad[B](ctx => List(ctx.parentGrad))
             .compileWithAttr("DstT", TensorType[B])
             .compileWithAllInputs
             .build

--- a/src/main/scala/org/scanet/core/CoreOp.scala
+++ b/src/main/scala/org/scanet/core/CoreOp.scala
@@ -99,7 +99,7 @@ object CoreOp {
             Output.name[A]("Reshape")
               .shape(shape)
               .inputs(op, Tensor.vector(shape.dims: _*).const)
-              .localGrad[A](ctx => List(reshape(ctx.parentGrad, op.shape)))
+              .localGrad(ctx => List(reshape(ctx.parentGrad, op.shape)))
               .compileWithAllInputs
               .build
           }
@@ -114,7 +114,7 @@ object CoreOp {
           Output.name[A]("Squeeze")
             .shape(squeezed)
             .inputs(op)
-            .localGrad[A](ctx => List(reshape(ctx.parentGrad, op.shape)))
+            .localGrad(ctx => List(reshape(ctx.parentGrad, op.shape)))
             .compileWithAllInputs
             .build
         } else {
@@ -128,7 +128,7 @@ object CoreOp {
           Output.name[B]("Cast")
             .shape(op.shape)
             .inputs(op)
-            .localGrad[B](ctx => List(ctx.parentGrad))
+            .localGrad(ctx => List(ctx.parentGrad))
             .compileWithAttr("DstT", TensorType[B])
             .compileWithAllInputs
             .build

--- a/src/main/scala/org/scanet/math/MathBaseOp.scala
+++ b/src/main/scala/org/scanet/math/MathBaseOp.scala
@@ -109,7 +109,7 @@ import scala.Ordering.Implicits._
    * @return a result of division
    */
   @op("/", alias = true)
-  def div[A: TensorType: Numeric, C](left: F[A], right: C)(implicit c: Convertible[C, F[A]]): F[Double]
+  def div[A: TensorType: Numeric, C](left: F[A], right: C)(implicit c: Convertible[C, F[A]]): F[A]
 
   /** Element-wise multiplication. Supports broadcasting.
    *
@@ -152,7 +152,7 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
       .shape(left.shape max rightOut.shape)
       .inputs(left, rightOut)
       .compileWithAllInputs
-      .localGrad[A](ctx => {
+      .localGrad(ctx => {
         val parentShape = ctx.parentGrad.shape
         val shrinkRightAxises = parentShape.broadcastableAxises(rightOut.shape)
         val shrinkLeftAxises = parentShape.broadcastableAxises(left.shape)
@@ -176,10 +176,10 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
       .shape(resultShape)
       .inputs(leftAdjusted, rightAdjusted)
       .compileWithAllInputs
-      .localGrad[A](ctx => {
+      .localGrad(ctx => {
         List(
-          multiply(ctx.parentGrad, transpose(rightAdjusted)),
-          multiply(transpose(leftAdjusted), ctx.parentGrad))
+          multiply(ctx.parentGrad, transpose(rightAdjusted).cast[Float]),
+          multiply(transpose(leftAdjusted).cast[Float], ctx.parentGrad))
       })
       .build
     val adjusted = 2 - math.min(left.shape.rank, rightOut.shape.rank)
@@ -193,7 +193,7 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
     Output.name[A]("Sub")
       .shape(left.shape max rightOut.shape)
       .inputs(left, rightOut)
-      .localGrad[A](ctx => {
+      .localGrad(ctx => {
         val parentShape = ctx.parentGrad.shape
         val shrinkLeftAxises = parentShape.broadcastableAxises(left.shape)
         val shrinkRightAxises = parentShape.broadcastableAxises(rightOut.shape)
@@ -207,29 +207,28 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
     Output.name[A]("Neg")
       .shape(out.shape)
       .inputs(out)
-      .localGrad[A](ctx => List(negate(ctx.parentGrad)))
+      .localGrad(ctx => List(negate(ctx.parentGrad)))
       .compileWithAllInputs
       .build
   }
 
-  override def div[A: TensorType: Numeric, C](left: Output[A], right: C)(implicit c: Convertible[C, Output[A]]): Output[Double] = {
-    val leftOut: Output[Double] = left.cast[Double]
-    val rightOut: Output[Double] = c.convert(right).cast[Double]
-    require(leftOut.broadcastableAny(rightOut),
+  override def div[A: TensorType: Numeric, C](left: Output[A], right: C)(implicit c: Convertible[C, Output[A]]): Output[A] = {
+    val rightOut: Output[A] = c.convert(right)
+    require(left.broadcastableAny(rightOut),
       s"cannot divide tensors with shapes ${left.shape} / ${rightOut.shape}")
-    Output.name[Double]("Div")
+    Output.name[A]("Div")
       .shape(left.shape max rightOut.shape)
-      .inputs(leftOut, rightOut)
-      .localGrad[Double](ctx => {
+      .inputs(left, rightOut)
+      .localGrad(ctx => {
         val parentShape = ctx.parentGrad.shape
         val shrinkRightAxises = parentShape.broadcastableAxises(rightOut.shape)
         val shrinkLeftAxises = parentShape.broadcastableAxises(left.shape)
         List(
-          sum(div(ctx.parentGrad, rightOut), shrinkLeftAxises),
+          sum(div(ctx.parentGrad, rightOut.cast[Float]), shrinkLeftAxises),
           sum(
             negate(div(
-                multiplyElementWise(leftOut, ctx.parentGrad),
-                multiplyElementWise(rightOut, rightOut)
+              multiplyElementWise(left.cast[Float], ctx.parentGrad),
+              multiplyElementWise(rightOut, rightOut).cast[Float]
             )),
             shrinkRightAxises
           )
@@ -247,13 +246,13 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
       .shape(left.shape max rightOut.shape)
       .inputs(left, rightOut)
       .compileWithAllInputs
-      .localGrad[A](ctx => {
+      .localGrad(ctx => {
         val parentShape = ctx.parentGrad.shape
         val shrinkRightAxises = parentShape.broadcastableAxises(rightOut.shape)
         val shrinkLeftAxises = parentShape.broadcastableAxises(left.shape)
         List(
-          sum(multiplyElementWise(rightOut, ctx.parentGrad), shrinkLeftAxises),
-          sum(multiplyElementWise(left, ctx.parentGrad), shrinkRightAxises)
+          sum(multiplyElementWise(rightOut.cast[Float], ctx.parentGrad), shrinkLeftAxises),
+          sum(multiplyElementWise(left.cast[Float], ctx.parentGrad), shrinkRightAxises)
         )
       })
       .build
@@ -266,7 +265,7 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
       Output.name[A]("Sum")
         .shape(out.shape.remove(axises: _*))
         .inputs(out, Tensor.vector(axises.map(_.toLong) :_*).const)
-        .localGrad[A](ctx => List(multiplyElementWise(Tensor.ones[A](out.shape).const, ctx.parentGrad)))
+        .localGrad(ctx => List(multiplyElementWise(Tensor.ones[Float](out.shape).const, ctx.parentGrad)))
         .compileWithAllInputs
         .build
     }
@@ -281,7 +280,7 @@ class OutputIsMathBaseOp extends MathBaseOp[Output] {
       Output.name[A]("Transpose")
         .shape(out.shape.permute(perm: _*))
         .inputs(out, Tensor.vector(perm.map(_.toLong) :_*).const)
-        .localGrad[A](ctx => List(transpose(ctx.parentGrad)))
+        .localGrad(ctx => List(transpose(ctx.parentGrad)))
         .compileWithAllInputs
         .build
     }
@@ -303,7 +302,7 @@ trait MathBaseMultiOp {
         .shape(shapes.head)
         .inputs(ops: _*)
         .compileWithInputList
-        .localGrad[A](ctx => List.fill(ops.size)(ctx.parentGrad))
+        .localGrad(ctx => List.fill(ops.size)(ctx.parentGrad))
         .build
     }
   }

--- a/src/main/scala/org/scanet/math/MathGradOp.scala
+++ b/src/main/scala/org/scanet/math/MathGradOp.scala
@@ -6,7 +6,7 @@ import org.scanet.math.MathBaseOp.syntax._
 import simulacrum.typeclass
 
 @typeclass trait MathGradOp[F[_]] {
-  def grad[A: TensorType: Numeric, B: TensorType : Numeric](current: F[A], withRespectTo: Output[B]): F[B]
+  def grad[A: TensorType: Numeric, B: TensorType : Numeric](current: F[A], withRespectTo: Output[B]): F[A]
 }
 
 object MathGradOp {
@@ -21,7 +21,7 @@ object MathGradOp {
 }
 
 class OutputIsMathGradOp extends MathGradOp[Output] {
-  override def grad[A: TensorType : Numeric, B: TensorType : Numeric](out: Output[A], withRespectTo: Output[B]): Output[B] = {
+  override def grad[A: TensorType : Numeric, B: TensorType : Numeric](out: Output[A], withRespectTo: Output[B]): Output[A] = {
     require(out.shape.isScalar, "gradient is supported on scalars only, " +
       "reduce the output with sum() or other operation")
     val graph = out.asGraph
@@ -40,6 +40,6 @@ class OutputIsMathGradOp extends MathGradOp[Output] {
         plus(grads.toList: _*)
       }
     }
-    leaf.map(gradRec).get.asInstanceOf[Output[B]]
+    leaf.map(gradRec).get.asInstanceOf[Output[A]]
   }
 }

--- a/src/main/scala/org/scanet/math/MathGradOp.scala
+++ b/src/main/scala/org/scanet/math/MathGradOp.scala
@@ -42,6 +42,5 @@ class OutputIsMathGradOp extends MathGradOp[Output] {
       }
     }
     leaf.map(gradRec).get
-
   }
 }

--- a/src/main/scala/org/scanet/math/MathGradOp.scala
+++ b/src/main/scala/org/scanet/math/MathGradOp.scala
@@ -3,10 +3,11 @@ package org.scanet.math
 import org.scanet.core.{Node, Output, Shape, Tensor, TensorType}
 import org.scanet.core.syntax._
 import org.scanet.math.MathBaseOp.syntax._
+import org.scanet.math.Numeric.syntax._
 import simulacrum.typeclass
 
 @typeclass trait MathGradOp[F[_]] {
-  def grad[A: TensorType: Numeric, B: TensorType : Numeric](current: F[A], withRespectTo: Output[B]): F[A]
+  def grad[A: TensorType : Numeric, B: TensorType : Numeric](current: F[A], withRespectTo: Output[B]): F[Float]
 }
 
 object MathGradOp {
@@ -21,25 +22,26 @@ object MathGradOp {
 }
 
 class OutputIsMathGradOp extends MathGradOp[Output] {
-  override def grad[A: TensorType : Numeric, B: TensorType : Numeric](out: Output[A], withRespectTo: Output[B]): Output[A] = {
+  override def grad[A: TensorType : Numeric, B: TensorType : Numeric](out: Output[A], withRespectTo: Output[B]): Output[Float] = {
     require(out.shape.isScalar, "gradient is supported on scalars only, " +
       "reduce the output with sum() or other operation")
     val graph = out.asGraph
     val leaf = graph.find(withRespectTo.id)
     require(leaf.isDefined, s"cannot find a gradient with respect to $withRespectTo " +
       s"cause that input is not a part of the computation graph")
-    def gradRec(node: Node[Output[_]]): Output[_] = {
+    def gradRec(node: Node[Output[_]]): Output[Float] = {
       if (node.isRoot) {
-        Tensor.ones[A](Shape()).const
+        Tensor.ones[Float](Shape()).const
       } else {
         val grads = node.outputs.map(edge => {
           val parent = edge.to
           val parentGrad = gradRec(parent)
-          parent.value.localGrad(edge.index, parentGrad).asInstanceOf[Output[A]]
+          parent.value.localGrad(edge.index, parentGrad)
         })
         plus(grads.toList: _*)
       }
     }
-    leaf.map(gradRec).get.asInstanceOf[Output[A]]
+    leaf.map(gradRec).get
+
   }
 }

--- a/src/test/scala/org/scanet/math/MathBaseOpSpec.scala
+++ b/src/test/scala/org/scanet/math/MathBaseOpSpec.scala
@@ -315,7 +315,7 @@ class MathBaseOpSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "work for floating point numbers" in {
-    (Tensor.vector(2, 4, 6).const / Tensor.vector(10, 10, 10).const).eval should be(Tensor.vector(0.2, 0.4, 0.6))
+    (Tensor.vector(2.0f, 4.0f, 6.0f).const / Tensor.vector(10.0f, 10.0f, 10.0f).const).eval should be(Tensor.vector(0.2f, 0.4f, 0.6f))
   }
 
   it should "support broadcasting" in {
@@ -340,8 +340,8 @@ class MathBaseOpSpec extends AnyFlatSpec with Matchers {
     val a = Tensor.vector(5, 10, 15).const
     val x = Tensor.vector(5, 5, 5).const
 
-    (a div x).sum.grad(x).eval should be(Tensor.vector(-0.2, -0.4, -0.6))
-    (a div x).sum.grad(a).eval should be(Tensor.vector(0.2, 0.2, 0.2))
+    (a div x).sum.grad(x).eval should be(Tensor.vector(-0.2f, -0.4f, -0.6f))
+    (a div x).sum.grad(a).eval should be(Tensor.vector(0.2f, 0.2f, 0.2f))
   }
 
   it should "calculate gradient for matrices with broadcasting when smaller tensor is differentiable value" in {
@@ -350,8 +350,8 @@ class MathBaseOpSpec extends AnyFlatSpec with Matchers {
       Array(24, 28, 32)).const
     val x = Tensor.vector(2, 4, 8).const
 
-    (a div x).sum.grad(x).eval should be(Tensor.vector(-9, -2.75, -0.8125))
-    (x div a).sum.grad(x).eval should be(Tensor.vector(0.125, 0.09821428571428571, 0.08125))
+    (a div x).sum.grad(x).eval should be(Tensor.vector(-9f, -2.75f, -0.8125f))
+    (x div a).sum.grad(x).eval should be(Tensor.vector(0.125f, 0.09821428f, 0.08125f))
   }
 
   it should "calculate gradient for matrices with broadcasting when bigger tensor is differentiable value" in {
@@ -360,10 +360,10 @@ class MathBaseOpSpec extends AnyFlatSpec with Matchers {
       Array(24, 28, 32)).const
     val x = Tensor.vector(2, 4, 8).const
 
-    (a div x).sum.grad(a).eval should be(Tensor.matrix(Array(0.5, 0.25, 0.125), Array(0.5, 0.25, 0.125)))
+    (a div x).sum.grad(a).eval should be(Tensor.matrix(Array(0.5f, 0.25f, 0.125f), Array(0.5f, 0.25f, 0.125f)))
     val grad = Tensor.matrix(
-      Array(-0.013888888888888888, -0.015625, -0.02),
-      Array(-0.003472222222222222, -0.00510204081632653, -0.0078125))
+      Array(-0.013888889f, -0.015625f, -0.02f),
+      Array(-0.0034722222f, -0.0051020407f, -0.0078125f))
     (x div a).sum.grad(a).eval should be(grad)
   }
 


### PR DESCRIPTION
implemented gradient (though I'm not 100% sure in it) for elementwise division and fixed couple of related issues:
* div op now returns Double type insted of origional type - otherwise result would be treated as type of input parameters so it might be rounded back to integer
* changed return type of `grad` op to type of root operation (instead of type of differentiable value) - so that we use correct TypeCoder (i.e. if we apply grad for div op by int param - result is Double so we should use Double coder and not Int coder of differentiable value)
* changed gradF for cast op - otherwise it would brake div grad because it would round Double back into Int
* added missing plusN tests