### PR TITLE
[POC] explicitly specify new SessionOutput type during composition

### DIFF
--- a/src/main/scala/org/scanet/core/TF.scala
+++ b/src/main/scala/org/scanet/core/TF.scala
@@ -31,13 +31,19 @@ class TF1[P1: TensorType, O: SessionInput, T: SessionOutput]
     })
   }
 
-  def compose[P1_OTHER: TensorType, P2_OTHER: TensorType, O_OTHER: SessionInput, T_OTHER: SessionOutput, O_NEW: SessionInput, T_NEW: SessionOutput]
-    (other: TF2[P1_OTHER, P2_OTHER, O_OTHER, T_OTHER])(via: (O, O_OTHER) => O_NEW): TF3[P1, P1_OTHER, P2_OTHER, O_NEW, T_NEW] = {
-    new TF3((a1, a2, a3) => {
-      val (p1, out) = builder(a1)
-      val (p2, p3, outOther) = other.builder(a2, a3)
-      (p1, p2, p3, via(out, outOther))
-    })
+  def compose[P1_OTHER: TensorType, P2_OTHER: TensorType, O_OTHER: SessionInput, T_OTHER: SessionOutput, O_NEW: SessionInput]
+  (other: TF2[P1_OTHER, P2_OTHER, O_OTHER, T_OTHER])(via: (O, O_OTHER) => O_NEW): Composition[P1_OTHER, P2_OTHER, O_OTHER, T_OTHER, O_NEW] =
+    new Composition(other, via)
+
+  class Composition[P1_OTHER: TensorType, P2_OTHER: TensorType, O_OTHER: SessionInput, T_OTHER: SessionOutput, O_NEW: SessionInput]
+  (private val other: TF2[P1_OTHER, P2_OTHER, O_OTHER, T_OTHER], private val via: (O, O_OTHER) => O_NEW) {
+    def into[T_NEW: SessionOutput]: TF3[P1, P1_OTHER, P2_OTHER, O_NEW, T_NEW] = {
+      new TF3((a1, a2, a3) => {
+        val (p1, out) = builder(a1)
+        val (p2, p3, outOther) = other.builder(a2, a3)
+        (p1, p2, p3, via(out, outOther))
+      })
+    }
   }
 }
 

--- a/src/test/scala/org/scanet/core/TFSpec.scala
+++ b/src/test/scala/org/scanet/core/TFSpec.scala
@@ -35,7 +35,7 @@ class TFSpec extends AnyFlatSpec with CustomMatchers {
     val identity = TF1((arg: Output[Int]) => arg).returns[Tensor[Int]]
     val plus = TF2((arg1: Output[Int], arg2: Output[Int]) =>
       arg1 + arg2).returns[Tensor[Int]]
-    val leftMultiplyRightSum: TF3[Int, Int, Int, Output[Int], Tensor[Int]] = identity.compose(plus)(_ * _)
+    val leftMultiplyRightSum = identity.compose(plus)(_ * _).into[Tensor[Int]]
     using(session => {
       val func = leftMultiplyRightSum.compile(session)
       func(scalar(4), scalar(2), scalar(3)) should be(scalar(20))
@@ -55,7 +55,7 @@ class TFSpec extends AnyFlatSpec with CustomMatchers {
     val identity = TF1((arg: Output[Int]) => arg).returns[Tensor[Int]]
     val plus = TF2((arg1: Output[Int], arg2: Output[Int]) =>
       arg1 + arg2).returns[Tensor[Int]]
-    val leftMultiplyRightSum: TF3[Int, Int, Int, Output[Int], Tensor[Int]] = identity.compose(plus)(_ * _)
+    val leftMultiplyRightSum = identity.compose(plus)(_ * _).into[Tensor[Int]]
     using(session => {
       val func = leftMultiplyRightSum.compile(session)
       func(scalar(4), scalar(2), scalar(3)) should be(scalar(20))


### PR DESCRIPTION
Note: I'm not sure about this, most liekly we can leave current API as is or come up with something more clever

make TF composition API a bit more convenient by adding new step `.into` to explicitly specify new SessionOutput type without repeating all other inferred types (like new SessionInput, args types, etc.) either in `.compose` type constructor or in variable name

pros: API usage looks a bit nicer, but only when new SessionOutput type cannot be (easily) inferred
cons: API implementation becomes even more uglier, we will get more repetition if such trick would be reusesd for other composition overloads 