### PR TITLE
fix paralell SBT build

### DIFF
--- a/src/main/scala/org/scanet/core/Session.scala
+++ b/src/main/scala/org/scanet/core/Session.scala
@@ -94,7 +94,7 @@ class Session extends AutoCloseable {
       state.cache.get(output.id) match {
         case Some((_, output)) =>
           val nativeOutput = output.output(0)
-          val nativeTensor = tensor.native.asInstanceOf[NativeTensor[_]]
+          val nativeTensor = tensor.ref.native
           runner.feed(nativeOutput, nativeTensor)
         case None => runner
       }

--- a/src/main/scala/org/scanet/core/Session.scala
+++ b/src/main/scala/org/scanet/core/Session.scala
@@ -94,7 +94,7 @@ class Session extends AutoCloseable {
       state.cache.get(output.id) match {
         case Some((_, output)) =>
           val nativeOutput = output.output(0)
-          val nativeTensor = tensor.ref.native
+          val nativeTensor = tensor.native
           runner.feed(nativeOutput, nativeTensor)
         case None => runner
       }

--- a/src/main/scala/org/scanet/core/Tensor.scala
+++ b/src/main/scala/org/scanet/core/Tensor.scala
@@ -10,10 +10,11 @@ import org.tensorflow.{Tensor => NativeTensor}
 import scala.collection.mutable.ArrayBuffer
 import scala.{specialized => sp}
 
-class Tensor[@sp A: TensorType](val ref: TensorRef[A], val view: View) {
+class Tensor[@sp A: TensorType](private val ref: TensorRef[A], val view: View) {
 
-  val buffer: TensorBuffer[A] = TensorBuffer[A](NativeTensorOps.buffer(ref.native), view.originalShape.power)
+  val buffer: TensorBuffer[A] = TensorBuffer[A](NativeTensorOps.buffer(native), view.originalShape.power)
 
+  def native: NativeTensor[A] = ref.native
   def shape: Shape = view.shape
   def rank: Int = shape.rank
   def power: Int = shape.power

--- a/src/main/scala/org/scanet/native/Disposable.scala
+++ b/src/main/scala/org/scanet/native/Disposable.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
  * @param deallocator a deallocator which will be called after the object is garbage collected
  */
 abstract class Disposable(private[Disposable] val deallocator: () => Unit) {
-  new PhantomReference[Disposable](this, Disposable.refs)
+  new PhantomReference(this, Disposable.refs)
 }
 
 object Disposable {
@@ -23,7 +23,7 @@ object Disposable {
       // that is a blocking call so we do not busy wait here
       refs.remove.foreach(ref => {
         try {
-          ref.get.foreach(r => r.deallocator())
+          ref.get.foreach(_.deallocator())
         } catch {
           case _: InterruptedException => Thread.currentThread.interrupt()
           case NonFatal(e) =>

--- a/src/main/scala/org/scanet/native/Disposable.scala
+++ b/src/main/scala/org/scanet/native/Disposable.scala
@@ -2,39 +2,34 @@ package org.scanet.native
 
 import java.util.concurrent.Executors
 
-import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.ref.{PhantomReference, Reference, ReferenceQueue}
+import scala.ref.{PhantomReference, ReferenceQueue}
 import scala.util.control.NonFatal
 
 /**
  * Allows an object to register a deallocator
  * @param deallocator a deallocator which will be called after the object is garbage collected
  */
-abstract class Disposable(deallocator: () => Unit) {
-  private val ref = new PhantomReference[Disposable](this, Disposable.refs)
-  Disposable.dealocators += (ref -> deallocator)
+abstract class Disposable(private[Disposable] val deallocator: () => Unit) {
+  new PhantomReference[Disposable](this, Disposable.refs)
 }
 
 object Disposable {
-  val dealocators: mutable.Map[Reference[Disposable], () => Unit] = mutable.Map()
   val refs = new ReferenceQueue[Disposable]
   implicit val executor: ExecutionContextExecutor =
-    ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+    ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
   Future {
     while (true) {
+      // that is a blocking call so we do not busy wait here
       refs.remove.foreach(ref => {
-        // that is a blocking call so we do not busy wait here
-        dealocators.remove(ref).foreach(deallocator => {
-          try {
-            deallocator()
-          } catch {
-            case _: InterruptedException => Thread.currentThread.interrupt()
-            case NonFatal(e) =>
-              Console.err.println("Error happened when cleaning up an object")
-              e.printStackTrace()
-          }
-        })
+        try {
+          ref.get.foreach(r => r.deallocator())
+        } catch {
+          case _: InterruptedException => Thread.currentThread.interrupt()
+          case NonFatal(e) =>
+            Console.err.println("Error happened when cleaning up an object")
+            e.printStackTrace()
+        }
       })
     }
   }


### PR DESCRIPTION
 * wrap native tensors in TensorRef not to close native tensor when projected tensor is GCed
 * now Tensor is not Disposable, only NativeRef is. So projected/sliced tensors can be simply GCed
 * remove HashMap from Disposable - mutations from multiple threads were not safe (and a bit expensive), Disposable already contains deallocator 