### PR TITLE
Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ project/plugins/project/
 .cache
 .lib/
 .DS_Store
-.idea
+.idea/
+benchmark/keras/env/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_cache:
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION "testOnly -- -l org.scalatest.tags.Slow"

--- a/benchmark/keras/README.md
+++ b/benchmark/keras/README.md
@@ -1,0 +1,15 @@
+Create virtual env
+```
+python -m venv env
+```
+
+Activate a virtual env:
+```
+source env/bin/activate
+```
+NOTE: configure PyCharm to use this env also
+
+Install libs:
+```
+pip install -r requirements.txt
+```

--- a/benchmark/keras/mnist_fully_connected.py
+++ b/benchmark/keras/mnist_fully_connected.py
@@ -1,0 +1,36 @@
+import tensorflow.keras as keras
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense
+import time
+
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+# Scale images to the [0, 1] range
+x_train = (x_train.astype("float32") / 255).reshape((-1, 784))
+x_test = (x_test.astype("float32") / 255).reshape((-1, 784))
+
+# convert class vectors to binary class matrices
+y_train = keras.utils.to_categorical(y_train, 10)
+y_test = keras.utils.to_categorical(y_test, 10)
+
+model = Sequential([
+  Dense(50, activation='sigmoid', input_shape=(784,)),
+  Dense(10, activation='softmax')
+])
+
+model.compile(
+  optimizer=keras.optimizers.Adam(lr=0.002),
+  loss='categorical_crossentropy',
+  metrics=['accuracy'],
+)
+
+start = time.time()
+# Train the model.
+model.fit(
+  x_train,
+  y_train,
+  epochs=200,
+  batch_size=1000,
+)
+end = time.time()
+print("took (sec):", end - start)

--- a/benchmark/keras/requirements.txt
+++ b/benchmark/keras/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow==1.15
+keras==2.3.1

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ scalacOptions ++= Seq(
 )
 
 parallelExecution in Test := false
+testOptions in Test ++= Seq(
+  Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
+  Tests.Argument(TestFrameworks.ScalaTest, "-oF")
+)
 
 fork in Test := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")

--- a/src/main/scala/org/scanet/core/Using.scala
+++ b/src/main/scala/org/scanet/core/Using.scala
@@ -1,0 +1,16 @@
+package org.scanet.core
+
+import scala.util.{Success, Failure, Try}
+
+object Using {
+  def resource[A <: AutoCloseable, B](resource: A)(block: A => B): B = {
+    Try(block(resource)) match {
+      case Success(result) =>
+        resource.close()
+        result
+      case Failure(e) =>
+        resource.close()
+        throw e
+    }
+  }
+}

--- a/src/main/scala/org/scanet/datasets/MNIST.scala
+++ b/src/main/scala/org/scanet/datasets/MNIST.scala
@@ -22,12 +22,12 @@ object MNIST {
     (loadTrainingSet(sc, trainingSize), loadTestSet(sc, testSize))
 
   def loadTrainingSet(sc: SparkContext, size: Int): RDD[Array[Float]] =
-    loadDataSetFrom2(sc, images = "train-images-idx3-ubyte.gz", labels = "train-labels-idx1-ubyte.gz", size)
+    loadDataSetFrom(sc, images = "train-images-idx3-ubyte.gz", labels = "train-labels-idx1-ubyte.gz", size)
 
   def loadTestSet(sc: SparkContext, size: Int): RDD[Array[Float]] =
-    loadDataSetFrom2(sc, images = "t10k-images-idx3-ubyte.gz", labels = "t10k-labels-idx1-ubyte.gz", size)
+    loadDataSetFrom(sc, images = "t10k-images-idx3-ubyte.gz", labels = "t10k-labels-idx1-ubyte.gz", size)
 
-  def loadDataSetFrom2(sc: SparkContext, images: String, labels: String, size: Int): RDD[Array[Float]] = {
+  def loadDataSetFrom(sc: SparkContext, images: String, labels: String, size: Int): RDD[Array[Float]] = {
     def read(path: String, via: DataInputStream => Seq[(Int, Array[Float])]) = {
       sc.binaryFiles(downloadOrCached(path).toAbsolutePath.toString, 1)
         .flatMap {

--- a/src/main/scala/org/scanet/datasets/MNIST.scala
+++ b/src/main/scala/org/scanet/datasets/MNIST.scala
@@ -1,14 +1,15 @@
 package org.scanet.datasets
 
-import java.io.{DataInputStream, FileInputStream}
+import java.io.DataInputStream
 import java.net.URL
 import java.nio.channels.{Channels, FileChannel}
-import java.nio.file.{Files, Path, Paths}
 import java.nio.file.StandardOpenOption.WRITE
+import java.nio.file.{Files, Path, Paths}
 import java.util.zip.GZIPInputStream
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.scanet.core.Using
 
 object MNIST {
 
@@ -21,50 +22,43 @@ object MNIST {
     (loadTrainingSet(sc, trainingSize), loadTestSet(sc, testSize))
 
   def loadTrainingSet(sc: SparkContext, size: Int): RDD[Array[Float]] =
-    loadDataSetFrom(sc, images = "train-images-idx3-ubyte.gz", labels = "train-labels-idx1-ubyte.gz", size)
+    loadDataSetFrom2(sc, images = "train-images-idx3-ubyte.gz", labels = "train-labels-idx1-ubyte.gz", size)
 
   def loadTestSet(sc: SparkContext, size: Int): RDD[Array[Float]] =
-    loadDataSetFrom(sc, images = "t10k-images-idx3-ubyte.gz", labels = "t10k-labels-idx1-ubyte.gz", size)
+    loadDataSetFrom2(sc, images = "t10k-images-idx3-ubyte.gz", labels = "t10k-labels-idx1-ubyte.gz", size)
 
-  def loadDataSetFrom(sc: SparkContext, images: String, labels: String, size: Int): RDD[Array[Float]] = {
-    val imagesRdd = sc.makeRDD(loadImages(images, size))
-    val labelsRdd = sc.makeRDD(loadLabels(labels, size))
+  def loadDataSetFrom2(sc: SparkContext, images: String, labels: String, size: Int): RDD[Array[Float]] = {
+    def read(path: String, via: DataInputStream => Seq[(Int, Array[Float])]) = {
+      sc.binaryFiles(downloadOrCached(path).toAbsolutePath.toString, 1)
+        .flatMap {
+          case (_, portableStream) =>
+            Using.resource(new DataInputStream(new GZIPInputStream(portableStream.open())))(via(_))
+        }
+    }
+    val imagesRdd = read(images, readImages(_, size))
+    val labelsRdd = read(labels, readLabels(_, size))
     imagesRdd.join(labelsRdd).map {
       case (_, (images, labels)) => images ++ labels
     }
   }
 
-  def loadImages(name: String, size: Int): Seq[(Int, Array[Float])] = {
-    openStream(downloadOrCached(name), stream => {
-      require(stream.readInt() == 2051, "wrong MNIST image stream magic number")
-      val count = stream.readInt()
-      val width = stream.readInt()
-      val height = stream.readInt()
-      require(size <= count, "passed size is bigger than the actual data set")
-      for (i <- 0 until size) yield (i, readImage(stream, height * width))
-    })
+  def readImages(stream: DataInputStream, size: Int): Seq[(Int, Array[Float])] = {
+    require(stream.readInt() == 2051, "wrong MNIST image stream magic number")
+    val count = stream.readInt()
+    val width = stream.readInt()
+    val height = stream.readInt()
+    require(size <= count, "passed size is bigger than the actual data set")
+    for (i <- 0 until size) yield (i, readImage(stream, height * width))
   }
 
-  def loadLabels(name: String, size: Int): Seq[(Int, Array[Float])] = {
-    openStream(downloadOrCached(name), stream => {
-      require(stream.readInt() == 2049, "wrong MNIST image stream magic number")
-      val count = stream.readInt()
-      require(size <= count, "passed size is bigger than the actual data set")
-      for (i <- 0 until size) yield (i, readLabel(stream, 10))
-    })
-  }
-
-  private def openStream[A](path: Path, f: DataInputStream => A) = {
-    val stream = new DataInputStream(new GZIPInputStream(new FileInputStream(path.toString)))
-    try {
-      f.apply(stream)
-    } finally {
-      stream.close()
-    }
+  def readLabels(stream: DataInputStream, size: Int): Seq[(Int, Array[Float])] = {
+    require(stream.readInt() == 2049, "wrong MNIST image stream magic number")
+    val count = stream.readInt()
+    require(size <= count, "passed size is bigger than the actual data set")
+    for (i <- 0 until size) yield (i, readLabel(stream, 10))
   }
 
   def readImage(stream: DataInputStream, size: Int): Array[Float] = {
-    // Array.range(0, size).map(_ => (stream.readUnsignedByte().toFloat / 127.5f) - 1f)
     Array.range(0, size).map(_ => (stream.readUnsignedByte().toFloat + 1f) / 256f)
   }
 

--- a/src/main/scala/org/scanet/estimators/package.scala
+++ b/src/main/scala/org/scanet/estimators/package.scala
@@ -6,7 +6,7 @@ import org.scanet.core.{Output, TF2, TensorType}
 import org.scanet.math.syntax._
 import org.scanet.math.{Floating, Numeric}
 import org.scanet.models.TrainedModel
-import org.scanet.optimizers.{Optimizer, Tensor2Iterator}
+import org.scanet.optimizers.Tensor2Iterator
 
 package object estimators {
 

--- a/src/main/scala/org/scanet/math/MathLogicalOp.scala
+++ b/src/main/scala/org/scanet/math/MathLogicalOp.scala
@@ -1,6 +1,5 @@
 package org.scanet.math
 
-import org.scanet.core.Output.Grad
 import org.scanet.core.syntax._
 import org.scanet.core.{Output, Tensor, TensorType}
 import org.scanet.math.Logical.syntax._

--- a/src/main/scala/org/scanet/models/Loss.scala
+++ b/src/main/scala/org/scanet/models/Loss.scala
@@ -49,7 +49,8 @@ object Loss {
       // - predicted 0 - then loss -indefinite (need epsilon here)
       // if we expect 0
       // - ignore result
-      (expected * (predicted + epsilon).log).mean.negate
+      val num = expected.shape.head.const.cast[A]
+      (expected * (predicted + epsilon).log).sum.negate / num
     }
   }
 }

--- a/src/main/scala/org/scanet/models/Loss.scala
+++ b/src/main/scala/org/scanet/models/Loss.scala
@@ -49,7 +49,7 @@ object Loss {
       // - predicted 0 - then loss -indefinite (need epsilon here)
       // if we expect 0
       // - ignore result
-      (expected * (predicted + epsilon).log).sum.negate
+      (expected * (predicted + epsilon).log).mean.negate
     }
   }
 }

--- a/src/main/scala/org/scanet/optimizers/AdaGrad.scala
+++ b/src/main/scala/org/scanet/optimizers/AdaGrad.scala
@@ -12,7 +12,7 @@ import org.scanet.syntax._
  * @param rate the learning rate.
  * @param epsilon a constant epsilon used to better conditioning the grad update
  */
-case class AdaGrad(rate: Float = 1.0f, epsilon: Float = 1e-7f) extends Algorithm {
+case class AdaGrad(rate: Float = 0.001f, epsilon: Float = 1e-7f) extends Algorithm {
 
   override def initMeta[T: Floating: Numeric: TensorType](shape: Shape): Tensor[T] = {
     Tensor.zeros[T](shape)
@@ -22,7 +22,7 @@ case class AdaGrad(rate: Float = 1.0f, epsilon: Float = 1e-7f) extends Algorithm
     // we accumulate all squared gradient per each weight
     val gradAcc = prevGradAcc + grad.sqr
     // the larger gradient is accumulated the lower rate is applied for a given weight
-    val rates = rate.const.cast[T] / (gradAcc.sqrt + epsilon.const.cast[T])
+    val rates = rate.const.cast[T] / gradAcc.sqrtZeroSafe(epsilon.const.cast[T])
     val delta = rates * grad
     Delta(delta, gradAcc)
   }

--- a/src/main/scala/org/scanet/optimizers/Adamax.scala
+++ b/src/main/scala/org/scanet/optimizers/Adamax.scala
@@ -17,11 +17,11 @@ import org.scanet.syntax._
  * @param beta2 The exponential decay rate for the exponentially weighted infinity norm
  * @param epsilon a constant epsilon used to better conditioning the grad update
  */
-case class Adamax(rate: Float = 0.001f, beta1: Float = 0.9f, beta2 : Float = 0.999f, epsilon: Float = 1e-7f) extends Algorithm {
+case class Adamax(rate: Float = 0.001f, beta1: Float = 0.9f, beta2 : Float = 0.999f, epsilon: Float = 1e-7f, initAcc: Float = 0.001f) extends Algorithm {
 
   override def initMeta[T: Floating: Numeric: TensorType](shape: Shape): Tensor[T] = {
-    val m1 = zeros[T](shape)
-    val m2 = zeros[T](shape)
+    val m1 = fill[Float](shape)(initAcc).cast[T]
+    val m2 = fill[Float](shape)(initAcc).cast[T]
     (m1 zip m2).eval
   }
 

--- a/src/main/scala/org/scanet/optimizers/Effect.scala
+++ b/src/main/scala/org/scanet/optimizers/Effect.scala
@@ -1,10 +1,10 @@
 package org.scanet.optimizers
 
 import org.apache.spark.rdd.RDD
-import org.scanet.core.{Session, TensorBoard, TensorType}
+import org.scanet.core.{TensorBoard, TensorType}
 import org.scanet.estimators._
-import org.scanet.math.{Convertible, Floating, Numeric}
 import org.scanet.math.syntax._
+import org.scanet.math.{Convertible, Floating, Numeric}
 
 trait Effect[E] extends (E => Unit){
   private val self = this

--- a/src/main/scala/org/scanet/optimizers/Nadam.scala
+++ b/src/main/scala/org/scanet/optimizers/Nadam.scala
@@ -6,15 +6,19 @@ import org.scanet.syntax._
 
 /** Much like Adam is essentially RMSprop with momentum, Nadam is Adam with Nesterov momentum.
  *
+ * NOTE: we might need to reimplement it, see
+ *  - https://pywick.readthedocs.io/en/stable/_modules/pywick/optimizers/nadam.html
+ *  - https://github.com/uralik/keras/blob/c89b7f632a2883d0742d9d89ab959e54f7ce0dd0/keras/optimizers.py
+ *
  * @param beta1 The exponential decay rate for the 1st moment estimates.
  * @param beta2 The exponential decay rate for the 2nd moment estimates.
  * @param epsilon a constant epsilon used to better conditioning the grad update
  */
-case class Nadam(beta1: Float = 0.9f, beta2 : Float = 0.999f, epsilon: Float = 1e-7f) extends Algorithm {
+case class Nadam(beta1: Float = 0.9f, beta2 : Float = 0.999f, epsilon: Float = 1e-7f, initAcc: Float = 0.001f) extends Algorithm {
 
   override def initMeta[T: Floating: Numeric: TensorType](shape: Shape): Tensor[T] = {
-    val m = zeros[T](shape)
-    val v = zeros[T](shape)
+    val m = fill[Float](shape)(initAcc).cast[T]
+    val v = fill[Float](shape)(initAcc).cast[T]
     (m zip v).eval
   }
 
@@ -22,7 +26,7 @@ case class Nadam(beta1: Float = 0.9f, beta2 : Float = 0.999f, epsilon: Float = 1
     val (prevM, prevV) = meta.unzip
     val m = prevM.decayingAvg(grad, beta1.const.cast[T])
     val v = prevV.decayingAvg(grad.sqr, beta2.const.cast[T])
-    val mNesterov = (beta1.const.cast[T] * m.boost(beta1.const.cast[T], iter))+
+    val mNesterov = (beta1.const.cast[T] * m.boost(beta1.const.cast[T], iter)) +
       ((1f.const.cast[T] - beta1.const.cast[T]) * grad.boost(beta1.const.cast[T], iter))
     val delta = mNesterov / (v.boost(beta2.const.cast[T], iter).sqrt + epsilon.const.cast[T])
     Delta(delta, m zip v)

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set everything to be logged to the console
-log4j.rootCategory=INFO, console
+log4j.rootCategory=WARN, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/src/test/scala/org/scanet/benchmarks/MNISTWithANNBenchmark.scala
+++ b/src/test/scala/org/scanet/benchmarks/MNISTWithANNBenchmark.scala
@@ -1,0 +1,73 @@
+package org.scanet.benchmarks
+
+import org.scalatest.tags.Slow
+import org.scalatest.wordspec.AnyWordSpec
+import org.scanet.estimators.accuracy
+import org.scanet.math.syntax._
+import org.scanet.models.Activation.{Sigmoid, Softmax}
+import org.scanet.models.Loss.CategoricalCrossentropy
+import org.scanet.models.layer.Dense
+import org.scanet.optimizers.Effect.{RecordAccuracy, RecordLoss}
+import org.scanet.optimizers._
+import org.scanet.optimizers.syntax._
+import org.scanet.test.{CustomMatchers, Datasets, SharedSpark}
+
+trait MNISTWithANNBehaviours {
+
+  this: AnyWordSpec with CustomMatchers with SharedSpark with Datasets =>
+
+  def successfullyTrainedWith(alg: Algorithm): Unit = {
+    "be successfully trained" in {
+      val (trainingDs, testDs) = MNIST()
+      val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
+      val trained = trainingDs.train(model)
+        .loss(CategoricalCrossentropy)
+        .using(alg)
+        .batch(1000)
+        .each(1.epochs, RecordLoss(tensorboard = true, dir = s"board/$alg"))
+        .each(5.epochs, RecordAccuracy(testDs, tensorboard = true, dir = s"board/$alg"))
+        .stopAfter(50.epochs)
+        .run()
+      accuracy(trained, testDs) should be >= 0.9f
+    }
+  }
+}
+
+@Slow
+class MNISTWithANNBenchmark extends AnyWordSpec with CustomMatchers with SharedSpark with Datasets with MNISTWithANNBehaviours {
+
+  "MNIST dataset with Fully Connected Neural Network architecture" when {
+
+    "used SDG algorithm" should {
+      behave like successfullyTrainedWith(SGD(rate = 0.6f, momentum = 0.9f))
+    }
+
+    "used AdaDelta algorithm" should {
+      behave like successfullyTrainedWith(AdaDelta())
+    }
+
+    "used RMSProp algorithm" should {
+      behave like successfullyTrainedWith(RMSProp())
+    }
+
+    "used Adam algorithm" should {
+      behave like successfullyTrainedWith(Adam(0.01f))
+    }
+
+    "used AMSGrad algorithm" should {
+      behave like successfullyTrainedWith(AMSGrad())
+    }
+
+    "used AdaGrad algorithm" should {
+      behave like successfullyTrainedWith(AdaGrad(rate = 0.05f))
+    }
+
+    "used Adamax algorithm" should {
+      behave like successfullyTrainedWith(Adamax(rate = 0.003f, initAcc = 0.01f))
+    }
+
+    "used Nadam algorithm" should {
+      behave like successfullyTrainedWith(Nadam())
+    }
+  }
+}

--- a/src/test/scala/org/scanet/benchmarks/RegressionBenchmark.scala
+++ b/src/test/scala/org/scanet/benchmarks/RegressionBenchmark.scala
@@ -1,155 +1,79 @@
 package org.scanet.benchmarks
 
-import org.scalatest.Ignore
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.tags.Slow
+import org.scalatest.wordspec.AnyWordSpec
 import org.scanet.math.syntax._
 import org.scanet.models.LinearRegression
 import org.scanet.models.Loss.MeanSquaredError
 import org.scanet.optimizers.Effect.RecordLoss
-import org.scanet.optimizers.syntax._
 import org.scanet.optimizers._
+import org.scanet.optimizers.syntax._
 import org.scanet.test.{CustomMatchers, Datasets, SharedSpark}
 
-@Ignore
-class RegressionBenchmark extends AnyFlatSpec with CustomMatchers with SharedSpark with Datasets {
+trait RegressionBehaviours {
 
-  "linear regression" should "be minimized by plain SDG" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(SGD())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/SDG"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
+  this: AnyWordSpec with CustomMatchers with SharedSpark with Datasets =>
+
+  def successfullyTrainedWith(alg: Algorithm): Unit = {
+    "be successfully trained" in {
+      val ds = facebookComments
+      val trained = ds.train(LinearRegression)
+        .loss(MeanSquaredError)
+        .using(SGD())
+        .batch(1000)
+        .each(1.epochs, RecordLoss(tensorboard = true, dir = s"board/$alg"))
+        .stopAfter(10.epochs)
+        .run()
+      val loss = trained.loss.compile()
+      val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
+      loss(x, y).toScalar should be <= 1f
+    }
   }
+}
 
-  it should "be minimized by SDG with momentum" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(SGD(momentum = 0.9f))
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/Momentum"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+@Slow
+class RegressionBenchmark extends AnyWordSpec with CustomMatchers with SharedSpark with Datasets with RegressionBehaviours {
 
-  it should "be minimized by SDG with nesterov acceleration" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(SGD(momentum = 0.9f, nesterov = true))
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/Nesterov"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+  "Linear regression should be minimized" when {
 
-  it should "be minimized by AdagGrad" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(AdaGrad())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/AdaGrad"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used SDG algorithm" should {
+      behave like successfullyTrainedWith(SGD())
+    }
 
-  it should "be minimized by AdagDelta" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(AdaDelta())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/AdaDelta"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used SDG algorithm with momentum" should {
+      behave like successfullyTrainedWith(SGD(momentum = 0.9f))
+    }
 
-  it should "be minimized by RMSProp" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(RMSProp())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/RMSProp"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used SDG algorithm with nesterov acceleration" should {
+      behave like successfullyTrainedWith(SGD(momentum = 0.9f, nesterov = true))
+    }
 
-  it should "be minimized by Adam" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(Adam(rate = 0.1f))
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/Adam"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used AdaDelta algorithm" should {
+      behave like successfullyTrainedWith(AdaDelta())
+    }
 
-  it should "be minimized by Adamax" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(Adamax())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/Adamax"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used RMSProp algorithm" should {
+      behave like successfullyTrainedWith(RMSProp())
+    }
 
-  it should "be minimized by Nadam" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(Nadam())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/Nadam"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
-  }
+    "used Adam algorithm" should {
+      behave like successfullyTrainedWith(Adam(0.1f))
+    }
 
-  it should "be minimized by AMSGrad" in {
-    val ds = facebookComments
-    val trained = ds.train(LinearRegression)
-      .loss(MeanSquaredError)
-      .using(AMSGrad())
-      .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true, dir = "board/AMSGrad"))
-      .stopAfter(10.epochs)
-      .run()
-    val loss = trained.loss.compile()
-    val (x, y) = Tensor2Iterator(ds.collect.iterator, 1000).next()
-    loss(x, y).toScalar should be <= 1f
+    "used AMSGrad algorithm" should {
+      behave like successfullyTrainedWith(AMSGrad())
+    }
+
+    "used AdaGrad algorithm" should {
+      behave like successfullyTrainedWith(AdaGrad(rate = 1f))
+    }
+
+    "used Adamax algorithm" should {
+      behave like successfullyTrainedWith(Adamax())
+    }
+
+    "used Nadam algorithm" should {
+      behave like successfullyTrainedWith(Nadam())
+    }
   }
 }

--- a/src/test/scala/org/scanet/datasets/MNISTSpec.scala
+++ b/src/test/scala/org/scanet/datasets/MNISTSpec.scala
@@ -1,7 +1,5 @@
 package org.scanet.datasets
 
-import java.util
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scanet.core.{Shape, Tensor, TensorBoard}
@@ -74,6 +72,4 @@ class MNISTSpec extends AnyFlatSpec with Matchers with SharedSpark {
     }
     acc.mkString("")
   }
-
-
 }

--- a/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
+++ b/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
@@ -53,29 +53,30 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
     model.withLoss(BinaryCrossentropy).displayGrad[Float](x = Shape(4, 3))
   }
 
-  "MNIST dataset" should "be trained with Softmax" ignore  {
-    val (trainingDs, testDs) = MNIST.load(sc, trainingSize = 30000)
+  "MNIST dataset" should "be trained with Softmax" in  {
+    val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
     val trained = trainingDs.train(model)
       .loss(CategoricalCrossentropy)
       .using(Adam(0.01f))
       .batch(1000)
       .each(1.epochs, RecordLoss())
-      .stopAfter(200.epochs)
+      .each(1.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1)))
+      .stopAfter(20.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.95f
   }
 
-  "MNIST dataset" should "be trained with Sigmoid" ignore {
+  "MNIST dataset" should "be trained with Sigmoid" in {
     val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Sigmoid)
     val trained = trainingDs.train(model)
       .loss(BinaryCrossentropy)
       .using(Adam(0.002f))
       .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = true))
-      .each(10.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1), tensorboard = true))
-      .stopAfter(200.epochs)
+      .each(1.epochs, RecordLoss(tensorboard = false))
+      .each(1.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1), tensorboard = false))
+      .stopAfter(20.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.9f
     TensorBoard("board")

--- a/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
+++ b/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
@@ -53,29 +53,29 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
     model.withLoss(BinaryCrossentropy).displayGrad[Float](x = Shape(4, 3))
   }
 
-  "MNIST dataset" should "be trained with Softmax" in  {
+  "MNIST dataset" should "be trained with Softmax" ignore {
     val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
     val trained = trainingDs.train(model)
       .loss(CategoricalCrossentropy)
-      .using(Adam(0.01f))
+      .using(Adam(0.002f))
       .batch(1000)
       .each(1.epochs, RecordLoss())
-      .each(1.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1)))
-      .stopAfter(20.epochs)
+      .each(10.epochs, RecordAccuracy(testDs))
+      .stopAfter(200.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.95f
   }
 
-  "MNIST dataset" should "be trained with Sigmoid" in {
+  "MNIST dataset" should "be trained with Sigmoid" ignore {
     val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Sigmoid)
     val trained = trainingDs.train(model)
       .loss(BinaryCrossentropy)
       .using(Adam(0.002f))
       .batch(1000)
-      .each(1.epochs, RecordLoss(tensorboard = false))
-      .each(1.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1), tensorboard = false))
+      .each(1.epochs, RecordLoss())
+      .each(1.epochs, RecordAccuracy(testDs.sample(withReplacement = false, fraction = 0.1)))
       .stopAfter(20.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.9f

--- a/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
+++ b/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
@@ -2,7 +2,6 @@ package org.scanet.models.layer
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scanet.core.{Shape, Tensor, TensorBoard}
-import org.scanet.datasets.MNIST
 import org.scanet.estimators.accuracy
 import org.scanet.images.Grayscale
 import org.scanet.models.Activation._
@@ -54,7 +53,7 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
   }
 
   "MNIST dataset" should "be trained with Softmax" ignore {
-    val (trainingDs, testDs) = MNIST.load(sc)
+    val (trainingDs, testDs) = MNIST()
     val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
     val trained = trainingDs.train(model)
       .loss(CategoricalCrossentropy)
@@ -68,7 +67,7 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
   }
 
   "MNIST dataset" should "be trained with Sigmoid" ignore {
-    val (trainingDs, testDs) = MNIST.load(sc)
+    val (trainingDs, testDs) = MNIST()
     val model = Dense(50, Sigmoid) >> Dense(10, Sigmoid)
     val trained = trainingDs.train(model)
       .loss(BinaryCrossentropy)

--- a/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
+++ b/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
@@ -53,16 +53,16 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
     model.withLoss(BinaryCrossentropy).displayGrad[Float](x = Shape(4, 3))
   }
 
-  "MNIST dataset" should "be trained with Softmax" ignore {
+  "MNIST dataset" should "be trained with Softmax" in {
     val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
     val trained = trainingDs.train(model)
       .loss(CategoricalCrossentropy)
-      .using(Adam(0.002f))
+      .using(Adam(0.01f))
       .batch(1000)
       .each(1.epochs, RecordLoss())
       .each(10.epochs, RecordAccuracy(testDs))
-      .stopAfter(200.epochs)
+      .stopAfter(50.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.95f
   }

--- a/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
+++ b/src/test/scala/org/scanet/models/layer/FullyConnectedNeuralNetworkSpec.scala
@@ -53,7 +53,7 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
     model.withLoss(BinaryCrossentropy).displayGrad[Float](x = Shape(4, 3))
   }
 
-  "MNIST dataset" should "be trained with Softmax" in {
+  "MNIST dataset" should "be trained with Softmax" ignore {
     val (trainingDs, testDs) = MNIST.load(sc)
     val model = Dense(50, Sigmoid) >> Dense(10, Softmax)
     val trained = trainingDs.train(model)
@@ -62,7 +62,7 @@ class FullyConnectedNeuralNetworkSpec extends AnyFlatSpec with CustomMatchers  w
       .batch(1000)
       .each(1.epochs, RecordLoss())
       .each(10.epochs, RecordAccuracy(testDs))
-      .stopAfter(50.epochs)
+      .stopAfter(25.epochs)
       .run()
     accuracy(trained, testDs) should be >= 0.95f
   }

--- a/src/test/scala/org/scanet/optimizers/AdaGradSpec.scala
+++ b/src/test/scala/org/scanet/optimizers/AdaGradSpec.scala
@@ -14,7 +14,7 @@ class AdaGradSpec extends AnyFlatSpec with CustomMatchers with SharedSpark with 
     val ds = linearFunction
     val trained = ds.train(LinearRegression)
       .loss(MeanSquaredError)
-      .using(AdaGrad())
+      .using(AdaGrad(rate = 1f))
       .initWith(Tensor.zeros(_))
       .batch(97)
       .stopAfter(100.epochs)

--- a/src/test/scala/org/scanet/optimizers/AdamSpec.scala
+++ b/src/test/scala/org/scanet/optimizers/AdamSpec.scala
@@ -14,6 +14,7 @@ class AdamSpec extends AnyFlatSpec with CustomMatchers with SharedSpark with Dat
 
   "Adam" should "minimize linear regression" in {
     val ds = linearFunction
+    val start = System.currentTimeMillis()
     val trained = ds.train(LinearRegression)
       .loss(MeanSquaredError)
       .using(Adam(rate = 0.1f))
@@ -25,6 +26,8 @@ class AdamSpec extends AnyFlatSpec with CustomMatchers with SharedSpark with Dat
     val loss = trained.loss.compile()
     val (x, y) = Tensor2Iterator(ds.collect.iterator, 97).next()
     loss(x, y).toScalar should be <= 10f
+    val stop = System.currentTimeMillis()
+    println(s"took ${stop - start}")
   }
 
   it should "minimize logistic regression" in {

--- a/src/test/scala/org/scanet/strings/StringOpsTest.scala
+++ b/src/test/scala/org/scanet/strings/StringOpsTest.scala
@@ -2,7 +2,7 @@ package org.scanet.strings
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scanet.core.Tensor
+import org.scanet.core.{Output, Tensor}
 import org.scanet.syntax._
 
 import scala.reflect.io.Path._

--- a/src/test/scala/org/scanet/test/Datasets.scala
+++ b/src/test/scala/org/scanet/test/Datasets.scala
@@ -19,6 +19,7 @@ trait Datasets {
       .csv(resource("linear_function_1.scv"))
       .rdd
       .map(row => Array[Float](row.getFloat(0), row.getFloat(1)))
+      .coalesce(1)
       .cache()
   }
 
@@ -32,6 +33,7 @@ trait Datasets {
       .csv(resource("logistic_regression_1.scv"))
       .rdd
       .map(row => Array[Float](row.getFloat(0), row.getFloat(1), row.getFloat(2)))
+      .coalesce(1)
       .cache()
   }
 
@@ -40,11 +42,12 @@ trait Datasets {
       .csv(resource("facebook-comments-scaled.csv"))
       .rdd
       .map(row => row.toSeq.map(v => v.asInstanceOf[String].toFloat).toArray)
+      .coalesce(1)
       .cache()
 
   val MNISTMemoized = core.memoize((trainingSize: Int, testSize: Int) => {
     val (training, test) = datasets.MNIST.load(sc, trainingSize, testSize)
-    (training.cache(), test.cache())
+    (training.coalesce(1).cache(), test.coalesce(1).cache())
   })
 
   def MNIST(trainingSize: Int = 60000, testSize: Int = 10000) = MNISTMemoized(trainingSize, testSize)

--- a/src/test/scala/org/scanet/test/Datasets.scala
+++ b/src/test/scala/org/scanet/test/Datasets.scala
@@ -10,7 +10,7 @@ trait Datasets {
 
   def zero: RDD[Array[Float]] = spark.sparkContext.parallelize(Seq[Array[Float]]())
 
-  def linearFunction: RDD[Array[Float]] = {
+  lazy val linearFunction: RDD[Array[Float]] = {
     spark.read
       .schema(StructType(Array(
         StructField("x", FloatType, nullable = false),
@@ -19,9 +19,10 @@ trait Datasets {
       .csv(resource("linear_function_1.scv"))
       .rdd
       .map(row => Array[Float](row.getFloat(0), row.getFloat(1)))
+      .cache()
   }
 
-  def logisticRegression: RDD[Array[Float]] = {
+  lazy val logisticRegression: RDD[Array[Float]] = {
     spark.read
       .schema(StructType(Array(
         StructField("x1", FloatType, nullable = false),
@@ -31,6 +32,7 @@ trait Datasets {
       .csv(resource("logistic_regression_1.scv"))
       .rdd
       .map(row => Array[Float](row.getFloat(0), row.getFloat(1), row.getFloat(2)))
+      .cache()
   }
 
   lazy val facebookComments: RDD[Array[Float]] =

--- a/src/test/scala/org/scanet/test/SharedSpark.scala
+++ b/src/test/scala/org/scanet/test/SharedSpark.scala
@@ -20,7 +20,7 @@ trait SharedSpark extends BeforeAndAfterAll {
 
   def conf = {
     new SparkConf()
-      .setMaster("local[2]")
+      .setMaster("local[*]")
       .setAppName("test")
       .set("spark.ui.enabled", "false")
       .set("spark.ui.showConsoleProgress", "false")

--- a/src/test/scala/org/scanet/test/SharedSpark.scala
+++ b/src/test/scala/org/scanet/test/SharedSpark.scala
@@ -20,11 +20,13 @@ trait SharedSpark extends BeforeAndAfterAll {
 
   def conf = {
     new SparkConf()
-      .setMaster("local[*]")
+      .setMaster("local[2]")
       .setAppName("test")
       .set("spark.ui.enabled", "false")
+      .set("spark.ui.showConsoleProgress", "false")
       .set("spark.app.id", appID)
       .set("spark.driver.host", "localhost")
+      .set("spark.sql.shuffle.partitions", "1")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.registrator", "org.scanet.optimizers.KryoSerializers")
   }


### PR DESCRIPTION
Keras with latest TF1 version is ~3 times faster then scala implementation (on MNIST):
- each computation operation is faster (4 vs 10ms using batch=1000, dataset= MNIST)
- Spark gives about 20% overhead

Improvements in tests: 
- improved MNIST dataset loading, now that is loaded much faster
- cached MNIST and other datasets in tests
- removed `@Ignore` from benchmarks and tagged with `@Slow` instead

To run tests without slow:
```
sbt "testOnly -- -l org.scalatest.tags.Slow"
```

To run slow tests only:
```
sbt "testOnly -- -n org.scalatest.tags.Slow"
```